### PR TITLE
Change not to propagate allocator.

### DIFF
--- a/include/metall/container/experimental/json/value.hpp
+++ b/include/metall/container/experimental/json/value.hpp
@@ -138,7 +138,20 @@ class value {
                                  std::true_type>) {
       m_allocator = other.m_allocator;
     }
-    m_data = other.m_data;
+
+    // Cannot do `m_data = other.m_data`
+    // because std::variant calls the allocator-extended copy constructor of the holding data,
+    // which ignores propagate_on_container_copy_assignment value.
+    if (other.is_object()) {
+      emplace_object() = other.as_object();
+    } else if (other.is_array()) {
+      emplace_array() = other.as_array();
+    } else if (other.is_string()) {
+      emplace_string() = other.as_string();
+    } else {
+      m_data = other.m_data;
+    }
+
     return *this;
   }
 

--- a/include/metall/stl_allocator.hpp
+++ b/include/metall/stl_allocator.hpp
@@ -17,9 +17,15 @@
 
 namespace metall {
 
-/// \brief A STL compatible allocator
-/// \tparam T The type of the object
-/// \tparam metall_manager_kernel_type The type of the manager kernel
+/// \brief A STL compatible allocator.
+/// \tparam T A object type.
+/// \tparam metall_manager_kernel_type A manager kernel type.
+/// \warning
+/// This allocator is not propagated during containers' copy assignment, move assignment, or swap
+/// (propagate_on_* types are std::false_type), as same as Boost.Interprocess.
+/// Therefore, performing the move assignment between two objects allocated by different Metall managers invokes
+/// copy operations instead of move operations.
+/// Also, swapping objects allocated by different Metall managers will result in undefined behavior.
 template <typename T, typename metall_manager_kernel_type>
 class stl_allocator {
 

--- a/include/metall/stl_allocator.hpp
+++ b/include/metall/stl_allocator.hpp
@@ -35,9 +35,9 @@ class stl_allocator {
   using const_void_pointer = typename std::pointer_traits<pointer>::template rebind<const void>;
   using difference_type = typename std::pointer_traits<pointer>::difference_type;
   using size_type = typename std::make_unsigned<difference_type>::type;
-  using propagate_on_container_copy_assignment = std::true_type;
-  using propagate_on_container_move_assignment = std::true_type;
-  using propagate_on_container_swap = std::true_type;
+  using propagate_on_container_copy_assignment = std::false_type;
+  using propagate_on_container_move_assignment = std::false_type;
+  using propagate_on_container_swap = std::false_type;
   using is_always_equal = std::false_type;
   using manager_kernel_type = metall_manager_kernel_type;
 

--- a/include/metall/stl_allocator.hpp
+++ b/include/metall/stl_allocator.hpp
@@ -21,11 +21,13 @@ namespace metall {
 /// \tparam T A object type.
 /// \tparam metall_manager_kernel_type A manager kernel type.
 /// \warning
-/// This allocator is not propagated during containers' copy assignment, move assignment, or swap
-/// (propagate_on_* types are std::false_type), as same as Boost.Interprocess.
-/// Therefore, performing the move assignment between two objects allocated by different Metall managers invokes
-/// copy operations instead of move operations.
-/// Also, swapping objects allocated by different Metall managers will result in undefined behavior.
+/// This allocator does not define propagate_on_* types, as same as Boost.Interprocess.
+/// Those types are going to be std::false_type in std::allocator_traits.
+/// Therefore, this allocator is not propagated during containers' copy assignment, move assignment, or swap.
+/// This configuration enables users to copy containers between different Metall managers easier.
+/// On the other hand, performing the move assignment between two containers allocated by different Metall managers
+/// invokes copy operations instead of move operations.
+/// Also, swapping containers allocated by different Metall managers will result in undefined behavior.
 template <typename T, typename metall_manager_kernel_type>
 class stl_allocator {
 
@@ -41,10 +43,6 @@ class stl_allocator {
   using const_void_pointer = typename std::pointer_traits<pointer>::template rebind<const void>;
   using difference_type = typename std::pointer_traits<pointer>::difference_type;
   using size_type = typename std::make_unsigned<difference_type>::type;
-  using propagate_on_container_copy_assignment = std::false_type;
-  using propagate_on_container_move_assignment = std::false_type;
-  using propagate_on_container_swap = std::false_type;
-  using is_always_equal = std::false_type;
   using manager_kernel_type = metall_manager_kernel_type;
 
   /// \brief Makes another allocator type for type T2
@@ -138,12 +136,6 @@ class stl_allocator {
   /// \param ptr A pointer to the object
   void destroy(const pointer &ptr) const {
     priv_destroy(ptr);
-  }
-  /// \brief Obtains the copy-constructed version of the allocator a.
-  /// \param a Allocator used by a standard container passed as an argument to a container copy constructor.
-  /// \return The allocator to use by the copy-constructed standard containers.
-  stl_allocator select_on_container_copy_construction(const stl_allocator &a) {
-    return stl_allocator(a);
   }
 
   // ----------------------------------- This class's unique public functions ----------------------------------- //

--- a/test/container/stl_allocator_test.cpp
+++ b/test/container/stl_allocator_test.cpp
@@ -51,21 +51,21 @@ TEST(StlAllocatorTest, Types) {
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::size_type), typeid(alloc_t::size_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_copy_assignment),
-                    typeid(alloc_t::propagate_on_container_copy_assignment));
+                    typeid(std::false_type));
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_copy_assignment),
                     typeid(std::false_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_move_assignment),
-                    typeid(alloc_t::propagate_on_container_move_assignment));
+                    typeid(std::false_type));
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_move_assignment),
                     typeid(std::false_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_swap),
-                    typeid(alloc_t::propagate_on_container_swap));
+                    typeid(std::false_type));
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_swap), typeid(std::false_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::is_always_equal),
-                    typeid(alloc_t::is_always_equal));
+                    typeid(std::false_type));
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::is_always_equal), typeid(std::false_type));
 
     using otherT = int;

--- a/test/container/stl_allocator_test.cpp
+++ b/test/container/stl_allocator_test.cpp
@@ -53,16 +53,16 @@ TEST(StlAllocatorTest, Types) {
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_copy_assignment),
                     typeid(alloc_t::propagate_on_container_copy_assignment));
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_copy_assignment),
-                    typeid(std::true_type));
+                    typeid(std::false_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_move_assignment),
                     typeid(alloc_t::propagate_on_container_move_assignment));
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_move_assignment),
-                    typeid(std::true_type));
+                    typeid(std::false_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_swap),
                     typeid(alloc_t::propagate_on_container_swap));
-    GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_swap), typeid(std::true_type));
+    GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::propagate_on_container_swap), typeid(std::false_type));
 
     GTEST_ASSERT_EQ(typeid(std::allocator_traits<alloc_t>::is_always_equal),
                     typeid(alloc_t::is_always_equal));


### PR DESCRIPTION
This PR sets `propagate_on*` types in the `stl_allocator` class to `std::false_type`, as same as Boost.Interprocess.

This PR will change the behaviors of the STL containers when they are copy assigned, move assigned, or swapped between different Metall managers.

```C++
auto *manager0 = new metall::manager(metall::create_only, "/tmp/dir0");
auto *manager1 = new metall::manager(metall::create_only, "/tmp/dir1");

auto *vec0 = manager0->construct<vector_t>(metall::anonymous_instance)(manager0->get_allocator());
vec0->push_back(10);

auto *vec1 = manager1->construct<vector_t>(metall::anonymous_instance)(manager1->get_allocator());

// This PR affects the behaviors of the following three operations:

// 1. copy assignment
*vec1 = *vec0;

// 2. move assignment
// However, copy will be performed instead of move.
*vec1 = std::move(*vec0);

// 3. swap
// !! This operation does work anymore
using std::swap;
swap(*vec1, *vec0);

// Can close the manager0 here which allocated vec0
// because the allocator in vec0 is not propagated to vec1,
// i.e., vec1 does not access memory resources in manager0.
delete manager0;

for (const auto &v: *vec1) {
  std::cout << v << std::endl;
}
```