### PR TITLE
Add a macro for linking with Boost.JSON lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmake-build-*/
 .idea
 *~
 ~*
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,6 @@ if (USE_ANONYMOUS_NEW_MAP)
     message(STATUS "Use the anonymous map for new map region")
 endif ()
 
-
 # Requirements for GCC
 if (NOT RUN_BUILD_AND_TEST_WITH_CI)
     if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"))

--- a/include/metall/json/json_fwd.hpp
+++ b/include/metall/json/json_fwd.hpp
@@ -12,11 +12,22 @@
 #include <string>
 #include <variant>
 
-#ifndef METALL_JSON_BOOST_JSON_SRC_INCLUDED
+#if defined(DOXYGEN_SKIP)
+/// \brief If defined, link with a buit Boost.JSON.
+#define METALL_LINK_WITH_BOOST_JSON
+
 /// \brief Include guard for boost/json/src.hpp
 #define METALL_JSON_BOOST_JSON_SRC_INCLUDED
+#endif
+
+#if METALL_LINK_WITH_BOOST_JSON
+#include <boost/json.hpp>
+#else
+#ifndef METALL_BOOST_JSON_SRC_INCLUDED
+#define METALL_BOOST_JSON_SRC_INCLUDED
 #include <boost/json/src.hpp>
-#endif  // METALL_JSON_BOOST_JSON_SRC_INCLUDED
+#endif  // METALL_BOOST_JSON_SRC_INCLUDED
+#endif // METALL_LINK_WITH_BOOST_JSON
 
 #include <metall/container/string.hpp>
 


### PR DESCRIPTION
This PR adds a macro `METALL_LINK_WITH_BOOST_JSON`.
If the macro is  defined, Metall JSON includes `<boost/json.hpp>`, assuming a built Boost.JSON library is linked instead of including it's header-only version.