### PR TITLE
Feature: Add ability to implement custom loggers

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -38,6 +38,9 @@ add_metall_executable(logger logger.cpp)
 
 add_metall_executable(concurrent concurrent.cpp)
 
+add_metall_executable(custom_logger custom_logger.cpp)
+target_compile_definitions(custom_logger PRIVATE METALL_LOGGER_EXTERN_C=1)
+
 if (BUILD_C)
     add_c_executable(c_api c_api.c)
     target_link_libraries(c_api PRIVATE metall_c)

--- a/example/custom_logger.cpp
+++ b/example/custom_logger.cpp
@@ -1,0 +1,33 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC and other Metall
+// Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#include <metall/metall.hpp>
+
+/// \brief converts the given level into string literal
+const char *log_lvl_to_string(metall_log_level lvl) {
+  switch (lvl) {
+    case metall_critical: return "CRIT";
+    case metall_error: return "ERROR";
+    case metall_warning: return "WARN";
+    case metall_info: return "INFO";
+    case metall_debug: return "DEBUG";
+    case metall_verbose: return "VERBOSE";
+    default: return "UNKNOWN";
+  }
+}
+
+/// \brief custom logger implementation
+/// Output looks different than default.
+extern "C" void metall_log(metall_log_level lvl, const char *file, size_t line_no, const char *message) {
+  std::cerr << log_lvl_to_string(lvl) << " metall{file=" << file
+            << ", line=" << line_no << "}: " << message << std::endl;
+}
+
+int main() {
+  // Do Metall operations
+  metall::manager manager(metall::create_only, "/tmp/dir");
+
+  return 0;
+}

--- a/example/logger.cpp
+++ b/example/logger.cpp
@@ -8,7 +8,7 @@
 int main() {
   // Set the log level to , for example, verbose.
   // The log level can be changed at any time.
-  metall::logger::set_log_level(metall::logger::level::verbose);
+  metall::logger::set_log_level(metall::logger::level_filter::verbose);
 
   // Enable the program to abort when a critical log message is displayed.
   metall::logger::abort_on_critical_error(true);

--- a/include/metall/detail/soft_dirty_page.hpp
+++ b/include/metall/detail/soft_dirty_page.hpp
@@ -6,6 +6,7 @@
 #ifndef METALL_DETAIL_UTILITY_SOFT_DIRTY_PAGE_HPP
 #define METALL_DETAIL_UTILITY_SOFT_DIRTY_PAGE_HPP
 
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <metall/detail/memory.hpp>

--- a/include/metall/logger_interface.h
+++ b/include/metall/logger_interface.h
@@ -1,0 +1,37 @@
+#ifndef METALL_LOGGER_INTERFACE_H
+#define METALL_LOGGER_INTERFACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// \brief Log message level
+typedef enum metall_log_level {
+  /// \brief Critical logger message
+  metall_critical = 5,
+  /// \brief Error logger message
+  metall_error = 4,
+  /// \brief Warning logger message
+  metall_warning = 3,
+  /// \brief Info logger message
+  metall_info = 2,
+  /// \brief Debug logger message
+  metall_debug = 1,
+  /// \brief Verbose (lowest priority) logger message
+  metall_verbose = 0,
+} metall_log_level;
+
+
+/// \brief Implementation of logging behaviour.
+///
+/// If METALL_LOGGER_EXTERN_C is defined this function does not have an implementation
+/// and is intended to be implemented by consuming applications.
+///
+/// If it is not defined the default implementation is in metall/logger.hpp.
+void metall_log(metall_log_level lvl, const char *file_name, size_t line_no, const char *message);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // METALL_LOGGER_INTERFACE_H

--- a/test/container/stl_allocator_test.cpp
+++ b/test/container/stl_allocator_test.cpp
@@ -141,7 +141,7 @@ TEST(StlAllocatorTest, Exception) {
 
   // Turn off log temporary because the following exception test cases could
   // show error messages
-  metall::logger::set_log_level(metall::logger::level::critical);
+  metall::logger::set_log_level(metall::logger::level_filter::critical);
 
   ASSERT_NO_THROW({ allocator.deallocate(allocator.allocate(1), 1); });
 
@@ -149,7 +149,7 @@ TEST(StlAllocatorTest, Exception) {
       { allocator.allocate(allocator.max_size() + 1); },
       std::bad_array_new_length);
 
-  metall::logger::set_log_level(metall::logger::level::error);
+  metall::logger::set_log_level(metall::logger::level_filter::error);
 }
 
 TEST(StlAllocatorTest, Container) {

--- a/test/kernel/manager_test.cpp
+++ b/test/kernel/manager_test.cpp
@@ -1325,7 +1325,7 @@ TEST(ManagerTest, Description) {
 TEST(ManagerTest, CheckSanity) {
   // This test should be run at the end of this execution unless reset the
   // values below:
-  metall::logger::set_log_level(metall::logger::level::silent);
+  metall::logger::set_log_level(metall::logger::level_filter::silent);
   metall::logger::abort_on_critical_error(false);
 
   {

--- a/verification/logger/verify_logger.cpp
+++ b/verification/logger/verify_logger.cpp
@@ -9,7 +9,6 @@
 using namespace metall;
 
 void log_cerr() {
-  logger::out(logger::level::silent, __FILE__, __LINE__, "silent logger");
   logger::out(logger::level::critical, __FILE__, __LINE__, "critical logger");
   logger::out(logger::level::error, __FILE__, __LINE__, "error logger");
   logger::out(logger::level::warning, __FILE__, __LINE__, "warning logger");
@@ -19,7 +18,6 @@ void log_cerr() {
 }
 
 void log_perror() {
-  logger::perror(logger::level::silent, __FILE__, __LINE__, "silent logger");
   logger::perror(logger::level::critical, __FILE__, __LINE__,
                  "critical logger");
   logger::perror(logger::level::error, __FILE__, __LINE__, "error logger");
@@ -37,37 +35,37 @@ int main() {
   log_perror();
 
   std::cerr << "\n--- Log level : silent ---" << std::endl;
-  logger::set_log_level(logger::level::silent);
+  logger::set_log_level(logger::level_filter::silent);
   log_cerr();
   log_perror();
 
   std::cerr << "\n--- Log level : critical ---" << std::endl;
-  logger::set_log_level(logger::level::critical);
+  logger::set_log_level(logger::level_filter::critical);
   log_cerr();
   log_perror();
 
   std::cerr << "\n--- Log level : error ---" << std::endl;
-  logger::set_log_level(logger::level::error);
+  logger::set_log_level(logger::level_filter::error);
   log_cerr();
   log_perror();
 
   std::cerr << "\n--- Log level : warning ---" << std::endl;
-  logger::set_log_level(logger::level::warning);
+  logger::set_log_level(logger::level_filter::warning);
   log_cerr();
   log_perror();
 
   std::cerr << "\n--- Log level : info ---" << std::endl;
-  logger::set_log_level(logger::level::info);
+  logger::set_log_level(logger::level_filter::info);
   log_cerr();
   log_perror();
 
   std::cerr << "\n--- Log level : debug ---" << std::endl;
-  logger::set_log_level(logger::level::debug);
+  logger::set_log_level(logger::level_filter::debug);
   log_cerr();
   log_perror();
 
   std::cerr << "\n--- Log level : verbose ---" << std::endl;
-  logger::set_log_level(logger::level::verbose);
+  logger::set_log_level(logger::level_filter::verbose);
   log_cerr();
   log_perror();
 


### PR DESCRIPTION
Hi,
this PR implements the ability to implement custom loggers in consuming applications. I've tried to keep the changes minimal, but there is still some room to make them even more minimal (see notes for details).

Some Notes:
- The way this is currently implemented you first have to define `METALL_LOGGER_EXTERN_C=1`
and then provide a defintion for `metall_log` somewhere. If you don't like how that works, feel free to suggest something else
- `metall_log` is intentionally an `extern "C"` interface so that it can be easily used in FFI/cross-language contexts, i.e. this gives the ability to implement the logger behaviour in a foreign language that is not `C` or `C++`, which has the advantage of having the ability to neatly integrate into the native logging interface of the foreign language
- There is one interface change: I removed the `silent` logger `level` and factored it out into the `level_filter`. The reason being that `silent` is not really a log level and there isn't really a point in ever logging silent messages, because they are always ignored. But of course this is an interface change so I would understand if you didn't like it, in that case I can revert this detail back to its original state. Otherwise no change in interface has occured (in the default configuration)