### PR TITLE
Feature: `metall::manager::read_only()`

### DIFF
--- a/include/metall/basic_manager.hpp
+++ b/include/metall/basic_manager.hpp
@@ -1345,6 +1345,23 @@ class basic_manager {
     return 0;
   }
 
+  /// \brief Returns if this manager was opened as read-only
+  /// \copydoc doc_thread_safe
+  ///
+  /// \return whether or not this manager was opened as read-only
+  bool read_only() const noexcept {
+    if (!check_sanity()) {
+      return true;
+    }
+    try {
+      return m_kernel->read_only();
+    } catch (...) {
+      logger::out(logger::level::error, __FILE__, __LINE__,
+                  "An exception has been thrown");
+    }
+    return true;
+  }
+
   // bool belongs_to_segment (const void *ptr) const
 
   /// \brief Checks the sanity.

--- a/include/metall/kernel/manager_kernel.hpp
+++ b/include/metall/kernel/manager_kernel.hpp
@@ -347,6 +347,10 @@ class manager_kernel {
   /// \return Returns the size of the application data segment.
   size_type get_segment_size() const;
 
+  /// \brief Returns if this kernel was opened as read-only
+  /// \return whether this kernel is read-only
+  bool read_only() const;
+
   /// \brief Takes a snapshot. The snapshot has a different UUID.
   /// \param destination_base_path Destination path
   /// \param clone Use clone (reflink) to copy data.

--- a/include/metall/kernel/manager_kernel_impl.ipp
+++ b/include/metall/kernel/manager_kernel_impl.ipp
@@ -444,6 +444,11 @@ manager_kernel<st, sst, cn, cs>::get_segment_size() const {
 }
 
 template <typename st, typename sst, typename cn, std::size_t cs>
+bool manager_kernel<st, sst, cn, cs>::read_only() const {
+  return m_segment_storage.read_only();
+}
+
+template <typename st, typename sst, typename cn, std::size_t cs>
 bool manager_kernel<st, sst, cn, cs>::snapshot(
     const path_type &destination_base_path, const bool clone,
     const int num_max_copy_threads) {

--- a/test/kernel/manager_test.cpp
+++ b/test/kernel/manager_test.cpp
@@ -36,11 +36,13 @@ TEST(ManagerTest, CreateAndOpenModes) {
     manager_type::remove(dir_path());
     {
       manager_type manager(metall::create_only, dir_path(), 1UL << 30UL);
+      ASSERT_FALSE(manager.read_only());
       ASSERT_NE(manager.construct<int>("int")(10), nullptr);
       ASSERT_TRUE(manager.destroy<int>("int"));
     }
     {
       manager_type manager(metall::create_only, dir_path(), 1UL << 30UL);
+      ASSERT_FALSE(manager.read_only());
       auto ret = manager.find<int>("int");
       ASSERT_EQ(ret.first, nullptr);
       ASSERT_FALSE(manager.destroy<int>("int"));
@@ -51,10 +53,12 @@ TEST(ManagerTest, CreateAndOpenModes) {
     manager_type::remove(dir_path());
     {
       manager_type manager(metall::create_only, dir_path(), 1UL << 30UL);
+      ASSERT_FALSE(manager.read_only());
       ASSERT_NE(manager.construct<int>("int")(10), nullptr);
     }
     {
       manager_type manager(metall::open_only, dir_path());
+      ASSERT_FALSE(manager.read_only());
       auto ret = manager.find<int>("int");
       ASSERT_NE(ret.first, nullptr);
       ASSERT_EQ(*(static_cast<int *>(ret.first)), 10);
@@ -66,16 +70,19 @@ TEST(ManagerTest, CreateAndOpenModes) {
     manager_type::remove(dir_path());
     {
       manager_type manager(metall::create_only, dir_path(), 1UL << 30UL);
+      ASSERT_FALSE(manager.read_only());
       ASSERT_NE(manager.construct<int>("int")(10), nullptr);
     }
     {
       manager_type manager(metall::open_read_only, dir_path());
+      ASSERT_TRUE(manager.read_only());
       auto ret = manager.find<int>("int");
       ASSERT_NE(ret.first, nullptr);
       ASSERT_EQ(*(static_cast<int *>(ret.first)), 10);
     }
     {
       manager_type manager(metall::open_only, dir_path());
+      ASSERT_FALSE(manager.read_only());
       auto ret = manager.find<int>("int");
       ASSERT_NE(ret.first, nullptr);
       ASSERT_EQ(*(static_cast<int *>(ret.first)), 10);
@@ -1331,12 +1338,14 @@ TEST(ManagerTest, CheckSanity) {
   {
     auto *manager = new manager_type(metall::create_only, dir_path());
     ASSERT_TRUE(manager->check_sanity());
+    ASSERT_FALSE(manager->read_only());
   }
 
   {
     auto *bad_manager =
         new manager_type(metall::open_only, dir_path().string() + "-invalid");
     ASSERT_FALSE(bad_manager->check_sanity());
+    ASSERT_TRUE(bad_manager->read_only());
   }
 }
 }  // namespace


### PR DESCRIPTION
This PR adds an accessor function to `metall::manager` that can be used to determine whether or not it was opened as read-only.

It uses the corresponding function from the segment storage to determine this.