### PR TITLE
Remove explicit `-fPIC` in C interface cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,6 @@ if (BUILD_C)
         return()
     endif ()
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-
     add_library(metall_c metall_c.cpp)
     add_library(${PROJECT_NAME}::metall_c ALIAS metall_c)
 


### PR DESCRIPTION
This PR just removes the explicit `-fPIC` that is added to the CXX_FLAGS for the C api.
Setting this flag explicitly is not necessary as it can be handled by passing `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` to cmake, if so desired.
