### PR TITLE
Remove explicit -fPIC for libmetall_c 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ option(JUST_INSTALL_METALL_HEADER "Just install Metall header files (do not buil
 option(BUILD_UTILITY "Build utility programs" OFF)
 option(BUILD_DOC "Build API documentation" OFF)
 option(BUILD_C "Build C examples and libraries" OFF)
+option(BUILD_SHARED_LIBS "Generate shared libraries" OFF)
 option(BUILD_EXAMPLE "Build the examples" OFF)
 option(BUILD_TEST "Build the test" OFF)
 option(RUN_LARGE_SCALE_TEST "Run large scale tests" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,21 @@ if (BUILD_C)
         return()
     endif ()
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-
+    if (BUILD_SHARED_LIBS)
+        message(STATUS "Building metall_c as a shared library")
+    else ()
+        message(STATUS "Building metall_c as a static library")
+    endif ()
+    # 'BUILD_SHARED_LIBS' variable is used to determine
+    # whether to build a shared library or a static library.
     add_library(metall_c metall_c.cpp)
+    get_target_property(PIC_metall_c metall_c POSITION_INDEPENDENT_CODE)
+    if (PIC_metall_c)
+        message(STATUS "POSITION_INDEPENDENT_CODE for metall_c : ON")
+    else ()
+        message(STATUS "POSITION_INDEPENDENT_CODE for metall_c : OFF")
+    endif ()
+
     add_library(${PROJECT_NAME}::metall_c ALIAS metall_c)
 
     target_include_directories(metall_c PUBLIC


### PR DESCRIPTION
- To generate a shared library, specify BUILD_SHARED_LIBS=ON with CMake.

- Stop hardcoding -fPIC option, and let CMake decide on a proper setting by default.