### PR TITLE
Return nullptr on 0 byte alloc

### DIFF
--- a/include/metall/stl_allocator.hpp
+++ b/include/metall/stl_allocator.hpp
@@ -156,6 +156,10 @@ class stl_allocator {
   // -------------------- //
 
   pointer priv_allocate(const size_type n) const {
+    if (n == 0) {
+      return nullptr;
+    }
+
     if (priv_max_size() < n) {
       throw std::bad_array_new_length();
     }
@@ -183,6 +187,10 @@ class stl_allocator {
 
   void priv_deallocate(pointer ptr,
                        [[maybe_unused]] const size_type size) const noexcept {
+    if (ptr == nullptr) {
+      return;
+    }
+
     if (!get_pointer_to_manager_kernel()) {
       logger::out(logger::level::error, __FILE__, __LINE__,
                   "nullptr: cannot access to manager kernel");


### PR DESCRIPTION
Currently passing 0 to `priv_allocate` causes `std::bad_alloc` which is unexpected for an allocator and causes unnecessary problems with code like:

```
// Pseudo-code
void process(items):
    mem* = allocate(items.size())
    for (i in items):
        do_stuff(i, mem)
    dealloc(mem)

// Nothing to process
process([])
```