### PR TITLE
Prevent opening datastore read-write after it was opened read-only

### DIFF
--- a/include/metall/detail/properly_closed_mark.hpp
+++ b/include/metall/detail/properly_closed_mark.hpp
@@ -1,0 +1,127 @@
+#ifndef METALL_DETAIL_PROPERLYCLOSED_MARK_HPP
+#define METALL_DETAIL_PROPERLYCLOSED_MARK_HPP
+
+#include <metall/tags.hpp>
+#include <metall/detail/file.hpp>
+
+#include <cassert>
+#include <filesystem>
+#include <utility>
+
+#include <fcntl.h>
+#include <sys/file.h>
+
+namespace metall::mtlldetail {
+
+/**
+ * A marker file on the filesystem that determines if and how the datastore
+ * is currently opened and if it was properly closed the last time it was opened.
+ *
+ * It allows multiple readers xor one writer.
+ * It uses the existence of the file in combination with flock(2) to achieve this.
+ */
+struct properly_closed_mark {
+private:
+  std::filesystem::path m_mark_path{};
+  int m_mark_fd = -1;
+  bool m_read_only = false;
+
+  void unlock() {
+    if (m_mark_fd < 0) {
+      return;
+    }
+
+    ::flock(m_mark_fd, LOCK_UN);
+    ::close(m_mark_fd);
+    m_mark_fd = -1;
+  }
+
+  bool open_mark() {
+    const int fd = ::open(m_mark_path.c_str(), O_RDONLY);
+    if (fd < 0) {
+      return false;
+    }
+
+    m_mark_fd = fd;
+    return true;
+  }
+
+  bool lock_exclusive() {
+    if (!open_mark()) {
+      return false;
+    }
+
+    const int ret = ::flock(m_mark_fd, LOCK_EX | LOCK_NB);
+    return ret == 0;
+  }
+
+  bool lock_shared() {
+    if (!open_mark()) {
+      return false;
+    }
+
+    const int ret = ::flock(m_mark_fd, LOCK_SH | LOCK_NB);
+    return ret == 0;
+  }
+
+public:
+  properly_closed_mark() noexcept = default;
+
+  bool create(const std::filesystem::path &path) {
+    m_mark_path = path;
+    m_read_only = false;
+
+    return remove_file(m_mark_path);
+  }
+
+  bool open(const std::filesystem::path &path, const bool read_only) {
+    m_mark_path = path;
+    m_read_only = read_only;
+
+    if (read_only) {
+      return lock_shared();
+    } else {
+      if (!lock_exclusive()) {
+        return false;
+      }
+
+      return remove_file(m_mark_path);
+    }
+  }
+
+  properly_closed_mark(const properly_closed_mark &other) = delete;
+  properly_closed_mark &operator=(const properly_closed_mark &other) = delete;
+
+  properly_closed_mark(properly_closed_mark &&other) noexcept
+    : m_mark_path{std::move(other.m_mark_path)},
+      m_mark_fd{std::exchange(other.m_mark_fd, -1)},
+      m_read_only{other.m_read_only} {
+  }
+
+  properly_closed_mark &operator=(properly_closed_mark &&other) noexcept {
+    assert(this != &other);
+    std::swap(m_mark_path, other.m_mark_path);
+    std::swap(m_mark_fd, other.m_mark_fd);
+    std::swap(m_read_only, other.m_read_only);
+    return *this;
+  }
+
+  ~properly_closed_mark() noexcept {
+    close();
+  }
+
+  void close() {
+    if (!m_read_only) {
+      create_file(m_mark_path);
+    }
+    unlock();
+  }
+
+  [[nodiscard]] bool is_read_only() const noexcept {
+    return m_read_only;
+  }
+};
+
+} // namespace metall::mtlldetail
+
+#endif //  METALL_DETAIL_PROPERLYCLOSED_MARK_HPP

--- a/include/metall/kernel/manager_kernel.hpp
+++ b/include/metall/kernel/manager_kernel.hpp
@@ -33,6 +33,7 @@
 #include <metall/detail/char_ptr_holder.hpp>
 #include <metall/detail/uuid.hpp>
 #include <metall/detail/ptree.hpp>
+#include <metall/detail/properly_closed_mark.hpp>
 
 #ifndef METALL_DISABLE_CONCURRENCY
 #define METALL_ENABLE_MUTEX_IN_MANAGER_KERNEL
@@ -496,7 +497,6 @@ class manager_kernel {
   static bool priv_check_version(const json_store &metadata_json);
   static bool priv_properly_closed(const path_type &base_path);
   static bool priv_mark_properly_closed(const path_type &base_path);
-  static bool priv_unmark_properly_closed(const path_type &base_path);
 
   // ---------- For constructed objects  ---------- //
   template <typename T, typename proxy>
@@ -559,6 +559,7 @@ class manager_kernel {
   // -------------------- //
   bool m_good{false};
   path_type m_base_path{};
+  mtlldetail::properly_closed_mark m_properly_closed_mark{};
   attributed_object_directory_type m_named_object_directory{};
   attributed_object_directory_type m_unique_object_directory{};
   attributed_object_directory_type m_anonymous_object_directory{};

--- a/include/metall/kernel/manager_kernel_impl.ipp
+++ b/include/metall/kernel/manager_kernel_impl.ipp
@@ -67,10 +67,7 @@ void manager_kernel<st, sst, cn, cs>::close() {
     m_good = false;
     m_segment_storage.release();
 
-    if (!m_segment_storage.read_only()) {
-      // This function must be called at the end
-      priv_mark_properly_closed(m_base_path);
-    }
+    m_properly_closed_mark.close();
   }
 }
 
@@ -687,13 +684,6 @@ bool manager_kernel<st, sst, cn, cs>::priv_mark_properly_closed(
 }
 
 template <typename st, typename sst, typename cn, std::size_t cs>
-bool manager_kernel<st, sst, cn, cs>::priv_unmark_properly_closed(
-    const path_type &base_path) {
-  return mdtl::remove_file(
-      storage::get_path(base_path, k_properly_closed_mark_file_name));
-}
-
-template <typename st, typename sst, typename cn, std::size_t cs>
 template <typename T, typename proxy>
 T *manager_kernel<st, sst, cn, cs>::priv_generic_construct(
     char_ptr_holder_type name, size_type length, bool try2find, proxy &pr) {
@@ -854,21 +844,15 @@ bool manager_kernel<st, sst, cn, cs>::priv_open(
     return false;
   }
 
-  if (!priv_properly_closed(base_path)) {
+  if (!m_properly_closed_mark.open(storage::get_path(base_path, k_properly_closed_mark_file_name),
+                                   read_only)) {
     logger::out(logger::level::error, __FILE__, __LINE__,
-                "Inconsistent data store — it was not closed properly and "
-                "might have been collapsed.");
+                "Unable to open data store — either it is already open, or it was not "
+                "closed properly and might have been collapsed.");
     return false;
   }
 
   m_base_path = base_path;
-
-  // Clear the consistent mark before opening with the write mode
-  if (!read_only && !priv_unmark_properly_closed(m_base_path)) {
-    logger::out(logger::level::error, __FILE__, __LINE__,
-                "Failed to erase the properly close mark before opening");
-    return false;
-  }
 
   if (!m_segment_storage.open(m_base_path, vm_reserve_size_request,
                               read_only)) {
@@ -908,7 +892,7 @@ bool manager_kernel<st, sst, cn, cs>::priv_create(
     return false;
   }
 
-  if (!priv_unmark_properly_closed(base_path)) {
+  if (!m_properly_closed_mark.create(storage::get_path(base_path, k_properly_closed_mark_file_name))) {
     std::stringstream ss;
     ss << "Failed to remove a closed mark under " << base_path;
     logger::out(logger::level::error, __FILE__, __LINE__, ss.str().c_str());

--- a/test/kernel/manager_test.cpp
+++ b/test/kernel/manager_test.cpp
@@ -89,6 +89,65 @@ TEST(ManagerTest, CreateAndOpenModes) {
       ASSERT_TRUE(manager.destroy<int>("int"));
     }
   }
+
+  // open combinations
+  {
+    manager_type::remove(dir_path());
+
+    // after create
+    {
+      manager_type manager{metall::create_only, dir_path()};
+      ASSERT_TRUE(manager.check_sanity());
+
+      {
+        manager_type manager2{metall::open_only, dir_path()};
+        ASSERT_FALSE(manager2.check_sanity());
+      }
+
+      {
+        manager_type manager2{metall::open_read_only, dir_path()};
+        ASSERT_FALSE(manager2.check_sanity());
+      }
+
+      {
+        manager_type manager2{metall::open_only, dir_path()};
+        ASSERT_FALSE(manager2.check_sanity());
+      }
+    }
+
+    // after open
+    {
+      manager_type manager{metall::open_only, dir_path()};
+      ASSERT_TRUE(manager.check_sanity());
+
+      {
+        manager_type manager2{metall::open_read_only, dir_path()};
+        ASSERT_FALSE(manager2.check_sanity());
+      }
+
+      {
+        manager_type manager2{metall::open_only, dir_path()};
+        ASSERT_FALSE(manager2.check_sanity());
+      }
+    }
+
+    // after read-only open
+    {
+      manager_type manager{metall::open_read_only, dir_path()};
+      ASSERT_TRUE(manager.check_sanity());
+
+      {
+        manager_type manager2{metall::open_read_only, dir_path()};
+        ASSERT_TRUE(manager2.check_sanity());
+
+        manager_type manager3{metall::open_only, dir_path()};
+        ASSERT_FALSE(manager3.check_sanity());
+      }
+
+      manager_type manager2{metall::open_read_only, dir_path()};
+      ASSERT_TRUE(manager2.check_sanity());
+    }
+  }
 }
 
 TEST(ManagerTest, ConstructArray) {


### PR DESCRIPTION
Close #346 

Implemented with a combination of `flock(2)` and file existence.
Logic:
- create: No file created. No file means nobody else can open it.
- open read-only: Try to lock file as shared (do not delete it). This means other readers can also lock it as shared as well.
- open read-write: First try to lock file exclusive (does not work if it is locked in shared mode, i.e. opened in read-only mode), then delete it. Nobody else can open it after this.


I cannot test this personally, but `flock(2)` should be available on linux, macos and bsd, see man pages:
- https://www.man7.org/linux/man-pages/man2/flock.2.html
- https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/flock.2.html
- https://man.freebsd.org/cgi/man.cgi?query=flock&sektion=2

It would be good if you could test if it actually exists on mac or bsd.