### PR TITLE
Fix: fclose call with nullptr

### DIFF
--- a/include/metall/detail/file.hpp
+++ b/include/metall/detail/file.hpp
@@ -184,7 +184,10 @@ inline bool create_file(const fs::path &file_path) {
     logger::perror(logger::level::error, __FILE__, __LINE__, ss.str().c_str());
     return false;
   }
-  if (!os_fsync(fd)) return false;
+  if (!os_fsync(fd)) {
+    os_close(fd);
+    return false;
+  }
   if (!os_close(fd)) return false;
 
   // Sync the parent directory

--- a/include/metall/detail/memory.hpp
+++ b/include/metall/detail/memory.hpp
@@ -130,8 +130,9 @@ inline std::pair<std::size_t, std::size_t> get_num_page_faults() {
       logger::out(logger::level::error, __FILE__, __LINE__, ss.str().c_str());
       minflt = majflt = 0;
     }
+
+    fclose(f);
   }
-  fclose(f);
 #else
 #ifdef METALL_VERBOSE_SYSTEM_SUPPORT_WARNING
 #warning "get_num_page_faults() is not supported in this environment"


### PR DESCRIPTION
Tiny fix:

- Calling fclose with nullptr is UB.
- And `create_file` potentially leaked a fd if an `fsync` call failed
