### PR TITLE
Release/v0.33

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif ()
 # Metall general configuration
 # -------------------------------------------------------------------------------- #
 project(Metall
-        VERSION 0.32
+        VERSION 0.33
         DESCRIPTION "A persistent memory allocator for data-centric analytics"
         HOMEPAGE_URL "https://github.com/LLNL/metall")
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Metall"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.32
+PROJECT_NUMBER         = v0.33
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/metall/defs.hpp
+++ b/include/metall/defs.hpp
@@ -65,23 +65,11 @@
 #endif
 
 // --------------------
-// Macros for the object cache
+// Macros for the segment allocator
 // --------------------
 
-/// \def METALL_MAX_PER_CPU_CACHE_SIZE
-/// The maximum size of the per CPU (logical CPU core) cache in bytes.
-#ifndef METALL_MAX_PER_CPU_CACHE_SIZE
-#define METALL_MAX_PER_CPU_CACHE_SIZE (1ULL << 20ULL)
-#endif
-
-/// \def METALL_NUM_CACHES_PER_CPU
-/// The number of caches per CPU (logical CPU core).
-#ifndef METALL_NUM_CACHES_PER_CPU
-#define METALL_NUM_CACHES_PER_CPU 2
-#endif
-
 #ifdef DOXYGEN_SKIP
-/// \brief A macro to disable concurrency support.
+/// \brief If defined, disable concurrency support.
 /// \details
 /// If this macro is defined, Metall disables concurrency support and optimizes
 /// the internal behavior for single-thread usage. Applications must not call
@@ -89,6 +77,45 @@
 /// hand, Metall still may use multi-threading for internal operations, such
 /// as synchronizing data with files.
 #define METALL_DISABLE_CONCURRENCY
+#endif
+
+// --------------------
+// Macros for the object cache
+// --------------------
+
+#ifdef DOXYGEN_SKIP
+/// \brief If defined, Metall disables the object cache feature.
+#define METALL_DISABLE_OBJECT_CACHE
+#endif
+
+/// \def METALL_NUM_OBJECT_CACHES
+/// The number of object caches. This value must be greater than 0.
+#ifdef DOXYGEN_SKIP
+#define METALL_NUM_OBJECT_CACHES 2
+#endif
+
+#if defined(METALL_NUM_OBJECT_CACHES) && METALL_NUM_OBJECT_CACHES <= 0
+#warning "METALL_NUM_OBJECT_CACHES must be > 0. This value is ignored."
+#undef METALL_NUM_OBJECT_CACHES
+#endif
+
+/// \def METALL_NUM_CACHES_PER_CPU
+/// The number of caches per CPU (logical CPU core). This value must be greater than 0.
+/// This number is used only when METALL_NUM_OBJECT_CACHES is not defined.
+#ifndef METALL_NUM_CACHES_PER_CPU
+#define METALL_NUM_CACHES_PER_CPU 2
+#endif
+
+#if METALL_NUM_CACHES_PER_CPU <= 0
+#warning "METALL_NUM_CACHES_PER_CPU must be > 0."
+#undef METALL_NUM_CACHES_PER_CPU
+#define METALL_NUM_CACHES_PER_CPU 2
+#endif
+
+/// \def METALL_MAX_PER_CPU_CACHE_SIZE
+/// The maximum size of the per CPU (logical CPU core) cache in bytes.
+#ifndef METALL_MAX_PER_CPU_CACHE_SIZE
+#define METALL_MAX_PER_CPU_CACHE_SIZE (1ULL << 20ULL)
 #endif
 
 // --------------------

--- a/include/metall/defs.hpp
+++ b/include/metall/defs.hpp
@@ -89,7 +89,8 @@
 #endif
 
 /// \def METALL_NUM_OBJECT_CACHES
-/// The number of object caches. This value must be greater than 0.
+/// The total number of object caches. If this macro is defined,
+/// its value must be greater than 0.
 #ifdef DOXYGEN_SKIP
 #define METALL_NUM_OBJECT_CACHES 2
 #endif
@@ -100,8 +101,9 @@
 #endif
 
 /// \def METALL_NUM_CACHES_PER_CPU
-/// The number of caches per CPU (logical CPU core). This value must be greater than 0.
-/// This number is used only when METALL_NUM_OBJECT_CACHES is not defined.
+/// The number of caches per CPU (logical CPU core).
+/// This value must be greater than 0.
+/// This macro is ignored if METALL_NUM_OBJECT_CACHES is defined.
 #ifndef METALL_NUM_CACHES_PER_CPU
 #define METALL_NUM_CACHES_PER_CPU 2
 #endif

--- a/include/metall/kernel/object_cache.hpp
+++ b/include/metall/kernel/object_cache.hpp
@@ -446,7 +446,7 @@ class object_cache {
   }
 
   explicit object_cache()
-      : m_num_caches(priv_get_num_cpus() * k_num_caches_per_cpu)
+      : m_num_caches(priv_get_num_cahes())
 #ifdef METALL_ENABLE_MUTEX_IN_OBJECT_CACHE
         ,
         m_mutex(m_num_caches)
@@ -542,6 +542,16 @@ class object_cache {
 
   inline static unsigned int priv_get_num_cpus() {
     return mdtl::get_num_cpus();
+  }
+
+  /// Calculate the number of caches to be used.
+  inline static unsigned int priv_get_num_cahes() {
+#ifdef METALL_NUM_OBJECT_CACHES
+    if (METALL_NUM_OBJECT_CACHES > 0) {
+      return METALL_NUM_OBJECT_CACHES;
+    }
+#endif
+    return priv_get_num_cpus() * k_num_caches_per_cpu;
   }
 
   inline size_type priv_cache_no() const {

--- a/include/metall/version.hpp
+++ b/include/metall/version.hpp
@@ -14,7 +14,7 @@
 ///  METALL_VERSION / 100 % 1000 // the minor version.
 ///  METALL_VERSION % 100 // the patch level.
 /// \endcode
-#define METALL_VERSION 3200
+#define METALL_VERSION 3300
 
 namespace metall {
 /// \brief Variable type to handle a version data.


### PR DESCRIPTION
This pull request updates Metall to version 0.33 and introduces new macros and logic for configuring the object cache behavior, providing more flexibility.

* Added new macros in `defs.hpp` to enable/disable the object cache and set the number of object caches, along with improved documentation for these macros.
* Added logic in `object_cache.hpp` to use the new `METALL_NUM_OBJECT_CACHES` macro if defined, or fall back to the per-CPU cache count, allowing users to control the total number of caches.
* Improved validation and defaulting for cache-related macros, ensuring they have valid values and providing warnings if not.