### PR TITLE
Release v0.33

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif ()
 # Metall general configuration
 # -------------------------------------------------------------------------------- #
 project(Metall
-        VERSION 0.32
+        VERSION 0.33
         DESCRIPTION "A persistent memory allocator for data-centric analytics"
         HOMEPAGE_URL "https://github.com/LLNL/metall")
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Metall"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v0.32
+PROJECT_NUMBER         = v0.33
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/metall/version.hpp
+++ b/include/metall/version.hpp
@@ -14,7 +14,7 @@
 ///  METALL_VERSION / 100 % 1000 // the minor version.
 ///  METALL_VERSION % 100 // the patch level.
 /// \endcode
-#define METALL_VERSION 3200
+#define METALL_VERSION 3300
 
 namespace metall {
 /// \brief Variable type to handle a version data.


### PR DESCRIPTION
This pull request updates Metall to version 0.33 and introduces new macros and logic for configuring the object cache behavior, providing more flexibility.

* Added new macros in `defs.hpp` to enable/disable the object cache and set the number of object caches, along with improved documentation for these macros.
* Added logic in `object_cache.hpp` to use the new `METALL_NUM_OBJECT_CACHES` macro if defined, or fall back to the per-CPU cache count, allowing users to control the total number of caches.
* Improved validation and defaulting for cache-related macros, ensuring they have valid values and providing warnings if not.